### PR TITLE
Fix invalid syntax code generated from an empty schema

### DIFF
--- a/src/__snapshots__/code-generator.test.ts.snap
+++ b/src/__snapshots__/code-generator.test.ts.snap
@@ -59,7 +59,6 @@ exports[`generateCode > generates code when empty typeInfos is passed 1`] = `
 } from '@mizdra/graphql-codegen-typescript-fabbrica/helper';
 import type {
   Maybe,
-,
 } from './types';
 
 export * from '@mizdra/graphql-codegen-typescript-fabbrica/helper';

--- a/src/__snapshots__/code-generator.test.ts.snap
+++ b/src/__snapshots__/code-generator.test.ts.snap
@@ -51,3 +51,18 @@ export type OptionalNode = OptionalBook | OptionalAuthor;
 
 "
 `;
+
+exports[`generateCode > generates code when empty typeInfos is passed 1`] = `
+"import {
+  type DefineTypeFactoryInterface,
+  defineTypeFactory,
+} from '@mizdra/graphql-codegen-typescript-fabbrica/helper';
+import type {
+  Maybe,
+,
+} from './types';
+
+export * from '@mizdra/graphql-codegen-typescript-fabbrica/helper';
+
+"
+`;

--- a/src/code-generator.test.ts
+++ b/src/code-generator.test.ts
@@ -73,4 +73,13 @@ describe('generateCode', () => {
     const actual = generateCode(config, typeInfos);
     expect(actual).toMatchSnapshot();
   });
+  it('generates code when empty typeInfos is passed', () => {
+    const config = fakeConfig({
+      typesFile: './types',
+      skipTypename: oneOf([true, false]),
+    });
+    const typeInfos: TypeInfo[] = [];
+    const actual = generateCode(config, typeInfos);
+    expect(actual).toMatchSnapshot();
+  });
 });

--- a/src/code-generator.ts
+++ b/src/code-generator.ts
@@ -4,8 +4,8 @@ import type { ObjectTypeInfo, TypeInfo } from './schema-scanner.js';
 function generatePreludeCode(config: Config, typeInfos: TypeInfo[]): string {
   const joinedTypeNames = typeInfos
     .filter(({ type }) => type === 'object')
-    .map(({ name }) => `  ${name}`)
-    .join(',\n');
+    .map(({ name }) => `  ${name},\n`)
+    .join('');
   const code = `
 import {
   type DefineTypeFactoryInterface${config.nonOptionalDefaultFields ? 'Required' : ''},
@@ -13,8 +13,7 @@ import {
 } from '@mizdra/graphql-codegen-typescript-fabbrica/helper';
 import type {
   Maybe,
-${joinedTypeNames},
-} from '${config.typesFile}';
+${joinedTypeNames}} from '${config.typesFile}';
 
 export * from '@mizdra/graphql-codegen-typescript-fabbrica/helper';
   `.trim();

--- a/src/schema-scanner.test.ts
+++ b/src/schema-scanner.test.ts
@@ -77,6 +77,13 @@ describe('getTypeInfos', () => {
       ]
     `);
   });
+  it('returns empty array when schema without type is passed', () => {
+    const schema = buildSchema(`
+    scalar Date
+    `);
+    const config: Config = fakeConfig();
+    expect(getTypeInfos(config, schema)).toMatchInlineSnapshot(`[]`);
+  });
   it('includes description comment', () => {
     const schema = buildSchema(`
       "The book"


### PR DESCRIPTION
follow-up: #91 