### PR TITLE
fix: emit `never` for abstract types with no possible types

### DIFF
--- a/src/code-generator.test.ts
+++ b/src/code-generator.test.ts
@@ -37,6 +37,18 @@ describe('generateOptionalTypeDefinitionCode', () => {
       "
     `);
   });
+  it('generates `never` for abstract types with no possible types', () => {
+    // e.g. an interface that no object type implements, or a union with no members
+    const typeInfo: TypeInfo = {
+      type: 'abstract',
+      name: 'EmptyInterface',
+      possibleTypes: [],
+    };
+    expect(generateOptionalTypeDefinitionCode(typeInfo)).toMatchInlineSnapshot(`
+      "export type OptionalEmptyInterface = never;
+      "
+    `);
+  });
 });
 
 describe('generateCode', () => {

--- a/src/code-generator.ts
+++ b/src/code-generator.ts
@@ -38,7 +38,10 @@ ${joinedPropDefinitions}
   } else {
     const { name, possibleTypes } = typeInfo;
     const comment = typeInfo.comment ?? '';
-    const joinedPossibleTypes = possibleTypes.map((type) => `Optional${type}`).join(' | ');
+    // Fall back to `never` for abstract types with no possible types (e.g. an
+    // interface that no object type implements, or a union with no members).
+    // Without this the joined string is empty, producing invalid `export type X = ;`.
+    const joinedPossibleTypes = possibleTypes.map((type) => `Optional${type}`).join(' | ') || 'never';
     return `
 ${comment}export type Optional${name} = ${joinedPossibleTypes};
 `.trimStart();


### PR DESCRIPTION
## What

When an abstract type has no possible types — an **interface that no object type implements**, or a **union with no members** — `generateOptionalTypeDefinitionCode` joined an empty array into an empty string, emitting invalid TypeScript:

```ts
export type OptionalPayCustomerBalanceError = ;
```

This is a syntax error and breaks the whole generated file (Prettier / `tsc` fail on it).

## Fix

Fall back to `never` when `possibleTypes` is empty:

```ts
const joinedPossibleTypes =
  possibleTypes.map((type) => `Optional${type}`).join(' | ') || 'never';
```

`never` is the correct model for an abstract type with zero concrete implementations, and abstract types don't get a `define…Factory`, so nothing else changes.

## Tests

Added a case to `generateOptionalTypeDefinitionCode` covering `possibleTypes: []`, asserting it emits `export type OptionalEmptyInterface = never;`.

Closes #96
