### PR TITLE
fix: run build before staging package in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,4 +18,6 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 26
+      - run: npm ci
+      - run: npm run build
       - run: npm stage publish


### PR DESCRIPTION
follow-up: #98 

## Summary
- The release workflow ran `npm stage publish` without ever running `npm ci`/`npm run build`, so the staged package never contained `dist` (it's gitignored and only produced by the build step).
- Add `npm ci` and `npm run build` before `npm stage publish`.

## Test plan
- [ ] After merge, cut a new patch release and confirm the published tarball on npm contains `dist`.