### PR TITLE
feat: require Node.js 22 or higher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22, 24, 26]
+        node: [22, 24, 26]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22, 24, 26]
+        node: [22, 24, 26]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@graphql-codegen/typescript": "^4.0.9",
         "@mizdra/oxfmt-config": "^0.2.0",
         "@mizdra/oxlint-config": "^0.5.0",
-        "@tsconfig/node18": "^18.2.4",
+        "@tsconfig/node22": "^22.0.5",
         "@tsconfig/strictest": "^2.0.5",
         "@types/node": "^22.5.5",
         "@vitest/browser": "^2.1.1",
@@ -39,7 +39,7 @@
         "vitest": "^2.1.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": "^22.0.0 || ^24.0.0 || >=26.0.0"
       },
       "peerDependencies": {
         "graphql": "^16.0.0"
@@ -3696,10 +3696,10 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
-    "node_modules/@tsconfig/node18": {
-      "version": "18.2.6",
-      "resolved": "https://npm.flatt.tech/@tsconfig/node18/-/node18-18.2.6.tgz",
-      "integrity": "sha512-eAWQzAjPj18tKnDzmWstz4OyWewLUNBm9tdoN9LayzoboRktYx3Enk1ZXPmThj55L7c4VWYq/Bzq0A51znZfhw==",
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.5",
+      "resolved": "https://npm.flatt.tech/@tsconfig/node22/-/node22-22.0.5.tgz",
+      "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@graphql-codegen/typescript": "^4.0.9",
     "@mizdra/oxfmt-config": "^0.2.0",
     "@mizdra/oxlint-config": "^0.5.0",
-    "@tsconfig/node18": "^18.2.4",
+    "@tsconfig/node22": "^22.0.5",
     "@tsconfig/strictest": "^2.0.5",
     "@types/node": "^22.5.5",
     "@vitest/browser": "^2.1.1",
@@ -107,6 +107,6 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": "^22.0.0 || ^24.0.0 || >=26.0.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["@tsconfig/strictest/tsconfig.json", "@tsconfig/node18/tsconfig.json"],
+  "extends": ["@tsconfig/strictest/tsconfig.json", "@tsconfig/node22/tsconfig.json"],
   "exclude": ["node_modules", "dist", "e2e"],
   "compilerOptions": {
     "module": "NodeNext",


### PR DESCRIPTION
Raise the minimum required Node.js version to 22.

## Changes

- `engines.node`: `>=18.0.0` → `^22.0.0 || ^24.0.0 || >=26.0.0`
- Drop Node 18/20 from the CI test/e2e matrix
- Switch `@tsconfig/node18` → `@tsconfig/node22`

## How to verify

`npm run lint`, `npm run build`, and `npm run test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
