### PR TITLE
chore: update dependencies to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "e2e/02-browser"
       ],
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^5.0.1",
-        "@graphql-codegen/visitor-plugin-common": "^4.0.1",
+        "@graphql-codegen/plugin-helpers": "^7.1.0",
+        "@graphql-codegen/visitor-plugin-common": "^7.2.0",
         "graphql-relay": "^0.10.2"
       },
       "devDependencies": {
@@ -456,79 +456,6 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-codegen/add/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "7.1.0",
-      "resolved": "https://npm.flatt.tech/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.1.0.tgz",
-      "integrity": "sha512-ieJH7kZ5oSZKBPJs7CvHMrFY/CLYLklqv74ir93qMwRna6geZsbIMoJzTDBXohxcQTITiProiYSGrEtZjIpYGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^11.2.0",
-        "change-case-all": "^2.1.0",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/add/node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/add/node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://npm.flatt.tech/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/add/node_modules/change-case-all": {
-      "version": "2.1.0",
-      "resolved": "https://npm.flatt.tech/change-case-all/-/change-case-all-2.1.0.tgz",
-      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "^5.2.0",
-        "sponge-case": "^2.0.2",
-        "swap-case": "^3.0.2",
-        "title-case": "^3.0.3"
-      }
-    },
-    "node_modules/@graphql-codegen/add/node_modules/sponge-case": {
-      "version": "2.0.3",
-      "resolved": "https://npm.flatt.tech/sponge-case/-/sponge-case-2.0.3.tgz",
-      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/add/node_modules/swap-case": {
-      "version": "3.0.3",
-      "resolved": "https://npm.flatt.tech/swap-case/-/swap-case-3.0.3.tgz",
-      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@graphql-codegen/cli": {
       "version": "7.2.0",
       "resolved": "https://npm.flatt.tech/@graphql-codegen/cli/-/cli-7.2.0.tgz",
@@ -592,65 +519,6 @@
         }
       }
     },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "7.1.0",
-      "resolved": "https://npm.flatt.tech/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.1.0.tgz",
-      "integrity": "sha512-ieJH7kZ5oSZKBPJs7CvHMrFY/CLYLklqv74ir93qMwRna6geZsbIMoJzTDBXohxcQTITiProiYSGrEtZjIpYGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^11.2.0",
-        "change-case-all": "^2.1.0",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://npm.flatt.tech/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/change-case-all": {
-      "version": "2.1.0",
-      "resolved": "https://npm.flatt.tech/change-case-all/-/change-case-all-2.1.0.tgz",
-      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "^5.2.0",
-        "sponge-case": "^2.0.2",
-        "swap-case": "^3.0.2",
-        "title-case": "^3.0.3"
-      }
-    },
     "node_modules/@graphql-codegen/cli/node_modules/cosmiconfig": {
       "version": "9.0.2",
       "resolved": "https://npm.flatt.tech/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
@@ -677,20 +545,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/sponge-case": {
-      "version": "2.0.3",
-      "resolved": "https://npm.flatt.tech/sponge-case/-/sponge-case-2.0.3.tgz",
-      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/swap-case": {
-      "version": "3.0.3",
-      "resolved": "https://npm.flatt.tech/swap-case/-/swap-case-3.0.3.tgz",
-      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@graphql-codegen/client-preset": {
       "version": "6.1.0",
@@ -726,127 +580,6 @@
         }
       }
     },
-    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "7.1.0",
-      "resolved": "https://npm.flatt.tech/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.1.0.tgz",
-      "integrity": "sha512-ieJH7kZ5oSZKBPJs7CvHMrFY/CLYLklqv74ir93qMwRna6geZsbIMoJzTDBXohxcQTITiProiYSGrEtZjIpYGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^11.2.0",
-        "change-case-all": "^2.1.0",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "7.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.2.0.tgz",
-      "integrity": "sha512-qqtTY8taONuxlR0HvD8z+zgWC3CfJ47M2rATx+geWNIN8v8Itc5TflHYxjkWAtNL6E3q7WZRY5P7se+2S3EjBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^7.1.0",
-        "@graphql-tools/optimize": "^2.0.0",
-        "@graphql-tools/relay-operation-optimizer": "^7.1.1",
-        "@graphql-tools/utils": "^11.2.0",
-        "auto-bind": "^5.0.0",
-        "change-case-all": "^2.1.0",
-        "dependency-graph": "^1.0.0",
-        "graphql-tag": "^2.11.0",
-        "parse-filepath": "^1.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/client-preset/node_modules/auto-bind": {
-      "version": "5.0.1",
-      "resolved": "https://npm.flatt.tech/auto-bind/-/auto-bind-5.0.1.tgz",
-      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@graphql-codegen/client-preset/node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://npm.flatt.tech/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/client-preset/node_modules/change-case-all": {
-      "version": "2.1.0",
-      "resolved": "https://npm.flatt.tech/change-case-all/-/change-case-all-2.1.0.tgz",
-      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "^5.2.0",
-        "sponge-case": "^2.0.2",
-        "swap-case": "^3.0.2",
-        "title-case": "^3.0.3"
-      }
-    },
-    "node_modules/@graphql-codegen/client-preset/node_modules/dependency-graph": {
-      "version": "1.0.0",
-      "resolved": "https://npm.flatt.tech/dependency-graph/-/dependency-graph-1.0.0.tgz",
-      "integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@graphql-codegen/client-preset/node_modules/sponge-case": {
-      "version": "2.0.3",
-      "resolved": "https://npm.flatt.tech/sponge-case/-/sponge-case-2.0.3.tgz",
-      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/client-preset/node_modules/swap-case": {
-      "version": "3.0.3",
-      "resolved": "https://npm.flatt.tech/swap-case/-/swap-case-3.0.3.tgz",
-      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@graphql-codegen/core": {
       "version": "6.2.0",
       "resolved": "https://npm.flatt.tech/@graphql-codegen/core/-/core-6.2.0.tgz",
@@ -865,79 +598,6 @@
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
-    },
-    "node_modules/@graphql-codegen/core/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "7.1.0",
-      "resolved": "https://npm.flatt.tech/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.1.0.tgz",
-      "integrity": "sha512-ieJH7kZ5oSZKBPJs7CvHMrFY/CLYLklqv74ir93qMwRna6geZsbIMoJzTDBXohxcQTITiProiYSGrEtZjIpYGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^11.2.0",
-        "change-case-all": "^2.1.0",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/core/node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/core/node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://npm.flatt.tech/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/core/node_modules/change-case-all": {
-      "version": "2.1.0",
-      "resolved": "https://npm.flatt.tech/change-case-all/-/change-case-all-2.1.0.tgz",
-      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "^5.2.0",
-        "sponge-case": "^2.0.2",
-        "swap-case": "^3.0.2",
-        "title-case": "^3.0.3"
-      }
-    },
-    "node_modules/@graphql-codegen/core/node_modules/sponge-case": {
-      "version": "2.0.3",
-      "resolved": "https://npm.flatt.tech/sponge-case/-/sponge-case-2.0.3.tgz",
-      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/core/node_modules/swap-case": {
-      "version": "3.0.3",
-      "resolved": "https://npm.flatt.tech/swap-case/-/swap-case-3.0.3.tgz",
-      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@graphql-codegen/gql-tag-operations": {
       "version": "6.1.0",
@@ -959,11 +619,10 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/@graphql-codegen/plugin-helpers": {
+    "node_modules/@graphql-codegen/plugin-helpers": {
       "version": "7.1.0",
       "resolved": "https://npm.flatt.tech/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.1.0.tgz",
       "integrity": "sha512-ieJH7kZ5oSZKBPJs7CvHMrFY/CLYLklqv74ir93qMwRna6geZsbIMoJzTDBXohxcQTITiProiYSGrEtZjIpYGg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/utils": "^11.2.0",
@@ -978,133 +637,6 @@
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
-    },
-    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "7.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.2.0.tgz",
-      "integrity": "sha512-qqtTY8taONuxlR0HvD8z+zgWC3CfJ47M2rATx+geWNIN8v8Itc5TflHYxjkWAtNL6E3q7WZRY5P7se+2S3EjBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^7.1.0",
-        "@graphql-tools/optimize": "^2.0.0",
-        "@graphql-tools/relay-operation-optimizer": "^7.1.1",
-        "@graphql-tools/utils": "^11.2.0",
-        "auto-bind": "^5.0.0",
-        "change-case-all": "^2.1.0",
-        "dependency-graph": "^1.0.0",
-        "graphql-tag": "^2.11.0",
-        "parse-filepath": "^1.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/auto-bind": {
-      "version": "5.0.1",
-      "resolved": "https://npm.flatt.tech/auto-bind/-/auto-bind-5.0.1.tgz",
-      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://npm.flatt.tech/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/change-case-all": {
-      "version": "2.1.0",
-      "resolved": "https://npm.flatt.tech/change-case-all/-/change-case-all-2.1.0.tgz",
-      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "^5.2.0",
-        "sponge-case": "^2.0.2",
-        "swap-case": "^3.0.2",
-        "title-case": "^3.0.3"
-      }
-    },
-    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/dependency-graph": {
-      "version": "1.0.0",
-      "resolved": "https://npm.flatt.tech/dependency-graph/-/dependency-graph-1.0.0.tgz",
-      "integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/sponge-case": {
-      "version": "2.0.3",
-      "resolved": "https://npm.flatt.tech/sponge-case/-/sponge-case-2.0.3.tgz",
-      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/swap-case": {
-      "version": "3.0.3",
-      "resolved": "https://npm.flatt.tech/swap-case/-/swap-case-3.0.3.tgz",
-      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "5.1.1",
-      "resolved": "https://npm.flatt.tech/@graphql-codegen/plugin-helpers/-/plugin-helpers-5.1.1.tgz",
-      "integrity": "sha512-28GHODK2HY1NhdyRcPP3sCz0Kqxyfiz7boIZ8qIxFYmpLYnlDgiYok5fhFLVSZihyOpCs4Fa37gVHf/Q4I2FEg==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.0.0",
-        "change-case-all": "1.0.15",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "lodash": "~4.17.0",
-        "tslib": "~2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/plugin-helpers/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://npm.flatt.tech/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "license": "0BSD"
     },
     "node_modules/@graphql-codegen/schema-ast": {
       "version": "6.1.0",
@@ -1123,79 +655,6 @@
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
-    },
-    "node_modules/@graphql-codegen/schema-ast/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "7.1.0",
-      "resolved": "https://npm.flatt.tech/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.1.0.tgz",
-      "integrity": "sha512-ieJH7kZ5oSZKBPJs7CvHMrFY/CLYLklqv74ir93qMwRna6geZsbIMoJzTDBXohxcQTITiProiYSGrEtZjIpYGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^11.2.0",
-        "change-case-all": "^2.1.0",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/schema-ast/node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/schema-ast/node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://npm.flatt.tech/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/schema-ast/node_modules/change-case-all": {
-      "version": "2.1.0",
-      "resolved": "https://npm.flatt.tech/change-case-all/-/change-case-all-2.1.0.tgz",
-      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "^5.2.0",
-        "sponge-case": "^2.0.2",
-        "swap-case": "^3.0.2",
-        "title-case": "^3.0.3"
-      }
-    },
-    "node_modules/@graphql-codegen/schema-ast/node_modules/sponge-case": {
-      "version": "2.0.3",
-      "resolved": "https://npm.flatt.tech/sponge-case/-/sponge-case-2.0.3.tgz",
-      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/schema-ast/node_modules/swap-case": {
-      "version": "3.0.3",
-      "resolved": "https://npm.flatt.tech/swap-case/-/swap-case-3.0.3.tgz",
-      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@graphql-codegen/typed-document-node": {
       "version": "7.1.0",
@@ -1216,127 +675,6 @@
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
-    },
-    "node_modules/@graphql-codegen/typed-document-node/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "7.1.0",
-      "resolved": "https://npm.flatt.tech/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.1.0.tgz",
-      "integrity": "sha512-ieJH7kZ5oSZKBPJs7CvHMrFY/CLYLklqv74ir93qMwRna6geZsbIMoJzTDBXohxcQTITiProiYSGrEtZjIpYGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^11.2.0",
-        "change-case-all": "^2.1.0",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typed-document-node/node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "7.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.2.0.tgz",
-      "integrity": "sha512-qqtTY8taONuxlR0HvD8z+zgWC3CfJ47M2rATx+geWNIN8v8Itc5TflHYxjkWAtNL6E3q7WZRY5P7se+2S3EjBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^7.1.0",
-        "@graphql-tools/optimize": "^2.0.0",
-        "@graphql-tools/relay-operation-optimizer": "^7.1.1",
-        "@graphql-tools/utils": "^11.2.0",
-        "auto-bind": "^5.0.0",
-        "change-case-all": "^2.1.0",
-        "dependency-graph": "^1.0.0",
-        "graphql-tag": "^2.11.0",
-        "parse-filepath": "^1.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typed-document-node/node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typed-document-node/node_modules/auto-bind": {
-      "version": "5.0.1",
-      "resolved": "https://npm.flatt.tech/auto-bind/-/auto-bind-5.0.1.tgz",
-      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@graphql-codegen/typed-document-node/node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://npm.flatt.tech/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/typed-document-node/node_modules/change-case-all": {
-      "version": "2.1.0",
-      "resolved": "https://npm.flatt.tech/change-case-all/-/change-case-all-2.1.0.tgz",
-      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "^5.2.0",
-        "sponge-case": "^2.0.2",
-        "swap-case": "^3.0.2",
-        "title-case": "^3.0.3"
-      }
-    },
-    "node_modules/@graphql-codegen/typed-document-node/node_modules/dependency-graph": {
-      "version": "1.0.0",
-      "resolved": "https://npm.flatt.tech/dependency-graph/-/dependency-graph-1.0.0.tgz",
-      "integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@graphql-codegen/typed-document-node/node_modules/sponge-case": {
-      "version": "2.0.3",
-      "resolved": "https://npm.flatt.tech/sponge-case/-/sponge-case-2.0.3.tgz",
-      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/typed-document-node/node_modules/swap-case": {
-      "version": "3.0.3",
-      "resolved": "https://npm.flatt.tech/swap-case/-/swap-case-3.0.3.tgz",
-      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@graphql-codegen/typescript": {
       "version": "6.1.0",
@@ -1384,274 +722,29 @@
         }
       }
     },
-    "node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "7.1.0",
-      "resolved": "https://npm.flatt.tech/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.1.0.tgz",
-      "integrity": "sha512-ieJH7kZ5oSZKBPJs7CvHMrFY/CLYLklqv74ir93qMwRna6geZsbIMoJzTDBXohxcQTITiProiYSGrEtZjIpYGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^11.2.0",
-        "change-case-all": "^2.1.0",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "7.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.2.0.tgz",
-      "integrity": "sha512-qqtTY8taONuxlR0HvD8z+zgWC3CfJ47M2rATx+geWNIN8v8Itc5TflHYxjkWAtNL6E3q7WZRY5P7se+2S3EjBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^7.1.0",
-        "@graphql-tools/optimize": "^2.0.0",
-        "@graphql-tools/relay-operation-optimizer": "^7.1.1",
-        "@graphql-tools/utils": "^11.2.0",
-        "auto-bind": "^5.0.0",
-        "change-case-all": "^2.1.0",
-        "dependency-graph": "^1.0.0",
-        "graphql-tag": "^2.11.0",
-        "parse-filepath": "^1.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript-operations/node_modules/auto-bind": {
-      "version": "5.0.1",
-      "resolved": "https://npm.flatt.tech/auto-bind/-/auto-bind-5.0.1.tgz",
-      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript-operations/node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://npm.flatt.tech/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/typescript-operations/node_modules/change-case-all": {
-      "version": "2.1.0",
-      "resolved": "https://npm.flatt.tech/change-case-all/-/change-case-all-2.1.0.tgz",
-      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "^5.2.0",
-        "sponge-case": "^2.0.2",
-        "swap-case": "^3.0.2",
-        "title-case": "^3.0.3"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript-operations/node_modules/dependency-graph": {
-      "version": "1.0.0",
-      "resolved": "https://npm.flatt.tech/dependency-graph/-/dependency-graph-1.0.0.tgz",
-      "integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript-operations/node_modules/sponge-case": {
-      "version": "2.0.3",
-      "resolved": "https://npm.flatt.tech/sponge-case/-/sponge-case-2.0.3.tgz",
-      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/typescript-operations/node_modules/swap-case": {
-      "version": "3.0.3",
-      "resolved": "https://npm.flatt.tech/swap-case/-/swap-case-3.0.3.tgz",
-      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "7.1.0",
-      "resolved": "https://npm.flatt.tech/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.1.0.tgz",
-      "integrity": "sha512-ieJH7kZ5oSZKBPJs7CvHMrFY/CLYLklqv74ir93qMwRna6geZsbIMoJzTDBXohxcQTITiProiYSGrEtZjIpYGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^11.2.0",
-        "change-case-all": "^2.1.0",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "7.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.2.0.tgz",
-      "integrity": "sha512-qqtTY8taONuxlR0HvD8z+zgWC3CfJ47M2rATx+geWNIN8v8Itc5TflHYxjkWAtNL6E3q7WZRY5P7se+2S3EjBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^7.1.0",
-        "@graphql-tools/optimize": "^2.0.0",
-        "@graphql-tools/relay-operation-optimizer": "^7.1.1",
-        "@graphql-tools/utils": "^11.2.0",
-        "auto-bind": "^5.0.0",
-        "change-case-all": "^2.1.0",
-        "dependency-graph": "^1.0.0",
-        "graphql-tag": "^2.11.0",
-        "parse-filepath": "^1.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript/node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript/node_modules/auto-bind": {
-      "version": "5.0.1",
-      "resolved": "https://npm.flatt.tech/auto-bind/-/auto-bind-5.0.1.tgz",
-      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript/node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://npm.flatt.tech/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/typescript/node_modules/change-case-all": {
-      "version": "2.1.0",
-      "resolved": "https://npm.flatt.tech/change-case-all/-/change-case-all-2.1.0.tgz",
-      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "^5.2.0",
-        "sponge-case": "^2.0.2",
-        "swap-case": "^3.0.2",
-        "title-case": "^3.0.3"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript/node_modules/dependency-graph": {
-      "version": "1.0.0",
-      "resolved": "https://npm.flatt.tech/dependency-graph/-/dependency-graph-1.0.0.tgz",
-      "integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript/node_modules/sponge-case": {
-      "version": "2.0.3",
-      "resolved": "https://npm.flatt.tech/sponge-case/-/sponge-case-2.0.3.tgz",
-      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/typescript/node_modules/swap-case": {
-      "version": "3.0.3",
-      "resolved": "https://npm.flatt.tech/swap-case/-/swap-case-3.0.3.tgz",
-      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "4.1.2",
-      "resolved": "https://npm.flatt.tech/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-4.1.2.tgz",
-      "integrity": "sha512-yk7iEAL1kYZ2Gi/pvVjdsZhul5WsYEM4Zcgh2Ev15VicMdJmPHsMhNUsZWyVJV0CaQCYpNOFlGD/11Ea3pn4GA==",
+      "version": "7.2.0",
+      "resolved": "https://npm.flatt.tech/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.2.0.tgz",
+      "integrity": "sha512-qqtTY8taONuxlR0HvD8z+zgWC3CfJ47M2rATx+geWNIN8v8Itc5TflHYxjkWAtNL6E3q7WZRY5P7se+2S3EjBg==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^5.0.3",
+        "@graphql-codegen/plugin-helpers": "^7.1.0",
         "@graphql-tools/optimize": "^2.0.0",
-        "@graphql-tools/relay-operation-optimizer": "^7.0.0",
-        "@graphql-tools/utils": "^10.0.0",
-        "auto-bind": "~4.0.0",
-        "change-case-all": "1.0.15",
-        "dependency-graph": "^0.11.0",
+        "@graphql-tools/relay-operation-optimizer": "^7.1.1",
+        "@graphql-tools/utils": "^11.2.0",
+        "auto-bind": "^5.0.0",
+        "change-case-all": "^2.1.0",
+        "dependency-graph": "^1.0.0",
         "graphql-tag": "^2.11.0",
         "parse-filepath": "^1.0.2",
-        "tslib": "~2.6.0"
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
-    },
-    "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://npm.flatt.tech/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "license": "0BSD"
     },
     "node_modules/@graphql-hive/signal": {
       "version": "2.0.0",
@@ -1682,25 +775,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/apollo-engine-loader/node_modules/@graphql-tools/utils": {
-      "version": "11.1.1",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.1.1.tgz",
-      "integrity": "sha512-MuWwacINZZV6mX1ZSk6CcV4XVQLsbKBG/hLd0QPhe4GHxjqr2ATjKsnnwlB0TKI+QQvj2U8ewu8WeAzz9kC2Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-tools/batch-execute": {
       "version": "10.0.9",
       "resolved": "https://npm.flatt.tech/@graphql-tools/batch-execute/-/batch-execute-10.0.9.tgz",
@@ -1720,25 +794,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/batch-execute/node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-tools/code-file-loader": {
       "version": "8.1.33",
       "resolved": "https://npm.flatt.tech/@graphql-tools/code-file-loader/-/code-file-loader-8.1.33.tgz",
@@ -1751,25 +806,6 @@
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/code-file-loader/node_modules/@graphql-tools/utils": {
-      "version": "11.1.1",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.1.1.tgz",
-      "integrity": "sha512-MuWwacINZZV6mX1ZSk6CcV4XVQLsbKBG/hLd0QPhe4GHxjqr2ATjKsnnwlB0TKI+QQvj2U8ewu8WeAzz9kC2Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -1796,25 +832,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/delegate/node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
@@ -1875,25 +892,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/executor-common/node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-tools/executor-graphql-ws": {
       "version": "3.1.5",
       "resolved": "https://npm.flatt.tech/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-3.1.5.tgz",
@@ -1911,25 +909,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/executor-graphql-ws/node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
@@ -1959,25 +938,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/executor-http/node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-tools/executor-legacy-ws": {
       "version": "1.1.30",
       "resolved": "https://npm.flatt.tech/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.1.30.tgz",
@@ -1990,44 +950,6 @@
         "isomorphic-ws": "^5.0.0",
         "tslib": "^2.4.0",
         "ws": "^8.21.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/executor-legacy-ws/node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/executor/node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -2049,25 +971,6 @@
         "micromatch": "^4.0.8",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/git-loader/node_modules/@graphql-tools/utils": {
-      "version": "11.1.1",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.1.1.tgz",
-      "integrity": "sha512-MuWwacINZZV6mX1ZSk6CcV4XVQLsbKBG/hLd0QPhe4GHxjqr2ATjKsnnwlB0TKI+QQvj2U8ewu8WeAzz9kC2Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -2120,25 +1023,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/github-loader/node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-tools/graphql-file-loader": {
       "version": "8.1.15",
       "resolved": "https://npm.flatt.tech/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.1.15.tgz",
@@ -2151,25 +1035,6 @@
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/graphql-file-loader/node_modules/@graphql-tools/utils": {
-      "version": "11.1.1",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.1.1.tgz",
-      "integrity": "sha512-MuWwacINZZV6mX1ZSk6CcV4XVQLsbKBG/hLd0QPhe4GHxjqr2ATjKsnnwlB0TKI+QQvj2U8ewu8WeAzz9kC2Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -2200,25 +1065,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/graphql-tag-pluck/node_modules/@graphql-tools/utils": {
-      "version": "11.1.1",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.1.1.tgz",
-      "integrity": "sha512-MuWwacINZZV6mX1ZSk6CcV4XVQLsbKBG/hLd0QPhe4GHxjqr2ATjKsnnwlB0TKI+QQvj2U8ewu8WeAzz9kC2Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-tools/import": {
       "version": "7.1.15",
       "resolved": "https://npm.flatt.tech/@graphql-tools/import/-/import-7.1.15.tgz",
@@ -2228,25 +1074,6 @@
       "dependencies": {
         "@graphql-tools/utils": "^11.1.1",
         "resolve-from": "5.0.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/import/node_modules/@graphql-tools/utils": {
-      "version": "11.1.1",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.1.1.tgz",
-      "integrity": "sha512-MuWwacINZZV6mX1ZSk6CcV4XVQLsbKBG/hLd0QPhe4GHxjqr2ATjKsnnwlB0TKI+QQvj2U8ewu8WeAzz9kC2Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2275,25 +1102,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/json-file-loader/node_modules/@graphql-tools/utils": {
-      "version": "11.1.1",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.1.1.tgz",
-      "integrity": "sha512-MuWwacINZZV6mX1ZSk6CcV4XVQLsbKBG/hLd0QPhe4GHxjqr2ATjKsnnwlB0TKI+QQvj2U8ewu8WeAzz9kC2Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-tools/load": {
       "version": "8.1.11",
       "resolved": "https://npm.flatt.tech/@graphql-tools/load/-/load-8.1.11.tgz",
@@ -2313,25 +1121,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/load/node_modules/@graphql-tools/utils": {
-      "version": "11.1.1",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.1.1.tgz",
-      "integrity": "sha512-MuWwacINZZV6mX1ZSk6CcV4XVQLsbKBG/hLd0QPhe4GHxjqr2ATjKsnnwlB0TKI+QQvj2U8ewu8WeAzz9kC2Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-tools/merge": {
       "version": "9.1.10",
       "resolved": "https://npm.flatt.tech/@graphql-tools/merge/-/merge-9.1.10.tgz",
@@ -2340,25 +1129,6 @@
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/utils": "^11.1.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
-      "version": "11.1.1",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.1.1.tgz",
-      "integrity": "sha512-MuWwacINZZV6mX1ZSk6CcV4XVQLsbKBG/hLd0QPhe4GHxjqr2ATjKsnnwlB0TKI+QQvj2U8ewu8WeAzz9kC2Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2400,24 +1170,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/relay-operation-optimizer/node_modules/@graphql-tools/utils": {
-      "version": "11.1.1",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.1.1.tgz",
-      "integrity": "sha512-MuWwacINZZV6mX1ZSk6CcV4XVQLsbKBG/hLd0QPhe4GHxjqr2ATjKsnnwlB0TKI+QQvj2U8ewu8WeAzz9kC2Xg==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-tools/schema": {
       "version": "10.0.34",
       "resolved": "https://npm.flatt.tech/@graphql-tools/schema/-/schema-10.0.34.tgz",
@@ -2427,25 +1179,6 @@
       "dependencies": {
         "@graphql-tools/merge": "^9.1.10",
         "@graphql-tools/utils": "^11.1.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
-      "version": "11.1.1",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.1.1.tgz",
-      "integrity": "sha512-MuWwacINZZV6mX1ZSk6CcV4XVQLsbKBG/hLd0QPhe4GHxjqr2ATjKsnnwlB0TKI+QQvj2U8ewu8WeAzz9kC2Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2482,29 +1215,10 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/url-loader/node_modules/@graphql-tools/utils": {
+    "node_modules/@graphql-tools/utils": {
       "version": "11.2.0",
       "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
       "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/utils": {
-      "version": "10.11.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-10.11.0.tgz",
-      "integrity": "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -2534,25 +1248,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/wrap/node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
@@ -4492,12 +3187,12 @@
       }
     },
     "node_modules/auto-bind": {
-      "version": "4.0.0",
-      "resolved": "https://npm.flatt.tech/auto-bind/-/auto-bind-4.0.0.tgz",
-      "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
+      "version": "5.0.1",
+      "resolved": "https://npm.flatt.tech/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4573,16 +3268,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://npm.flatt.tech/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "license": "MIT",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001800",
       "resolved": "https://npm.flatt.tech/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
@@ -4603,17 +3288,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/capital-case": {
-      "version": "1.0.4",
-      "resolved": "https://npm.flatt.tech/capital-case/-/capital-case-1.0.4.tgz",
-      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -4639,41 +3313,21 @@
       }
     },
     "node_modules/change-case": {
-      "version": "4.1.2",
-      "resolved": "https://npm.flatt.tech/change-case/-/change-case-4.1.2.tgz",
-      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "license": "MIT",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
+      "version": "5.4.4",
+      "resolved": "https://npm.flatt.tech/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "license": "MIT"
     },
     "node_modules/change-case-all": {
-      "version": "1.0.15",
-      "resolved": "https://npm.flatt.tech/change-case-all/-/change-case-all-1.0.15.tgz",
-      "integrity": "sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==",
+      "version": "2.1.0",
+      "resolved": "https://npm.flatt.tech/change-case-all/-/change-case-all-2.1.0.tgz",
+      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
       "license": "MIT",
       "dependencies": {
-        "change-case": "^4.1.2",
-        "is-lower-case": "^2.0.2",
-        "is-upper-case": "^2.0.2",
-        "lower-case": "^2.0.2",
-        "lower-case-first": "^2.0.2",
-        "sponge-case": "^1.0.1",
-        "swap-case": "^2.0.2",
-        "title-case": "^3.0.3",
-        "upper-case": "^2.0.2",
-        "upper-case-first": "^2.0.2"
+        "change-case": "^5.2.0",
+        "sponge-case": "^2.0.2",
+        "swap-case": "^3.0.2",
+        "title-case": "^3.0.3"
       }
     },
     "node_modules/chardet": {
@@ -4784,17 +3438,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/constant-case": {
-      "version": "3.0.4",
-      "resolved": "https://npm.flatt.tech/constant-case/-/constant-case-3.0.4.tgz",
-      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
       }
     },
     "node_modules/convert-source-map": {
@@ -4923,12 +3566,12 @@
       }
     },
     "node_modules/dependency-graph": {
-      "version": "0.11.0",
-      "resolved": "https://npm.flatt.tech/dependency-graph/-/dependency-graph-0.11.0.tgz",
-      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+      "version": "1.0.0",
+      "resolved": "https://npm.flatt.tech/dependency-graph/-/dependency-graph-1.0.0.tgz",
+      "integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6.0"
+        "node": ">=4"
       }
     },
     "node_modules/detect-indent": {
@@ -4965,16 +3608,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://npm.flatt.tech/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/e2e-browser": {
@@ -5303,25 +3936,6 @@
         }
       }
     },
-    "node_modules/graphql-config/node_modules/@graphql-tools/utils": {
-      "version": "11.1.1",
-      "resolved": "https://npm.flatt.tech/@graphql-tools/utils/-/utils-11.1.1.tgz",
-      "integrity": "sha512-MuWwacINZZV6mX1ZSk6CcV4XVQLsbKBG/hLd0QPhe4GHxjqr2ATjKsnnwlB0TKI+QQvj2U8ewu8WeAzz9kC2Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/graphql-config/node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://npm.flatt.tech/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -5413,16 +4027,6 @@
         "ws": {
           "optional": true
         }
-      }
-    },
-    "node_modules/header-case": {
-      "version": "2.0.4",
-      "resolved": "https://npm.flatt.tech/header-case/-/header-case-2.0.4.tgz",
-      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "license": "MIT",
-      "dependencies": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/iconv-lite": {
@@ -5565,15 +4169,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://npm.flatt.tech/is-lower-case/-/is-lower-case-2.0.2.tgz",
-      "integrity": "sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://npm.flatt.tech/is-number/-/is-number-7.0.0.tgz",
@@ -5619,15 +4214,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-upper-case": {
-      "version": "2.0.2",
-      "resolved": "https://npm.flatt.tech/is-upper-case/-/is-upper-case-2.0.2.tgz",
-      "integrity": "sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/is-windows": {
@@ -6055,12 +4641,6 @@
         "node": ">=22.13.0"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://npm.flatt.tech/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
-    },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://npm.flatt.tech/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -6168,24 +4748,6 @@
       },
       "bin": {
         "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://npm.flatt.tech/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/lower-case-first": {
-      "version": "2.0.2",
-      "resolved": "https://npm.flatt.tech/lower-case-first/-/lower-case-first-2.0.2.tgz",
-      "integrity": "sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/lru-cache": {
@@ -6325,16 +4887,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://npm.flatt.tech/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "license": "MIT",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/node-domexception": {
@@ -6606,16 +5158,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://npm.flatt.tech/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://npm.flatt.tech/parent-module/-/parent-module-1.0.1.tgz",
@@ -6660,26 +5202,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://npm.flatt.tech/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/path-case": {
-      "version": "3.0.4",
-      "resolved": "https://npm.flatt.tech/path-case/-/path-case-3.0.4.tgz",
-      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/path-key": {
@@ -7023,17 +5545,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/sentence-case": {
-      "version": "3.0.4",
-      "resolved": "https://npm.flatt.tech/sentence-case/-/sentence-case-3.0.4.tgz",
-      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://npm.flatt.tech/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -7132,16 +5643,6 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "node_modules/snake-case": {
-      "version": "3.0.4",
-      "resolved": "https://npm.flatt.tech/snake-case/-/snake-case-3.0.4.tgz",
-      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://npm.flatt.tech/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7153,13 +5654,10 @@
       }
     },
     "node_modules/sponge-case": {
-      "version": "1.0.1",
-      "resolved": "https://npm.flatt.tech/sponge-case/-/sponge-case-1.0.1.tgz",
-      "integrity": "sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
+      "version": "2.0.3",
+      "resolved": "https://npm.flatt.tech/sponge-case/-/sponge-case-2.0.3.tgz",
+      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
+      "license": "MIT"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -7216,13 +5714,10 @@
       }
     },
     "node_modules/swap-case": {
-      "version": "2.0.2",
-      "resolved": "https://npm.flatt.tech/swap-case/-/swap-case-2.0.2.tgz",
-      "integrity": "sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
+      "version": "3.0.3",
+      "resolved": "https://npm.flatt.tech/swap-case/-/swap-case-3.0.3.tgz",
+      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
+      "license": "MIT"
     },
     "node_modules/sync-fetch": {
       "version": "0.6.0",
@@ -7464,24 +5959,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/upper-case": {
-      "version": "2.0.2",
-      "resolved": "https://npm.flatt.tech/upper-case/-/upper-case-2.0.2.tgz",
-      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/upper-case-first": {
-      "version": "2.0.2",
-      "resolved": "https://npm.flatt.tech/upper-case-first/-/upper-case-first-2.0.2.tgz",
-      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/urlpattern-polyfill": {

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "setup-playwright": "npx playwright install --with-deps chromium"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^5.0.1",
-    "@graphql-codegen/visitor-plugin-common": "^4.0.1",
+    "@graphql-codegen/plugin-helpers": "^7.1.0",
+    "@graphql-codegen/visitor-plugin-common": "^7.2.0",
     "graphql-relay": "^0.10.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Bump `@graphql-codegen/plugin-helpers` (^5.0.1 → ^7.1.0) and `@graphql-codegen/visitor-plugin-common` (^4.0.1 → ^7.2.0) to their latest major versions

## Test plan
- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run lint`
- [x] `npm run e2e`